### PR TITLE
Update UIViewController+GKExtension.swift

### DIFF
--- a/Sources/UIViewController+GKExtension.swift
+++ b/Sources/UIViewController+GKExtension.swift
@@ -477,6 +477,16 @@ extension UIViewController {
         if self.isKind(of: UIAlertController.self) { return }
         if NSStringFromClass(self.classForCoder).components(separatedBy: ".").last == "PUPhotoPickerHostViewController" { return }
         if self.navigationController == nil { return }
+        // 新增判断：如果是正在 pop 过渡，则不处理导航栏显示/隐藏
+        if let coordinator = self.transitionCoordinator {
+            // 判断是否是从其他页面 pop 回来
+            if let fromVC = coordinator.viewController(forKey: .from),
+               !self.navigationController!.viewControllers.contains(fromVC) {
+                // 是 pop 操作，直接调用原始方法，不做导航栏处理
+                gk_viewWillAppear(animated)
+                return
+            }
+        }
         
         if self.gk_navBarInit {
             let disableFixNavItemSpace = self.gk_disableFixNavItemSpace


### PR DESCRIPTION
解决无系统头部的A页面push出有系统头部的B页面，B页面点击返回按钮pop的过程中，页面A的gk_viewWillAppear会调用hiddenSystemNavBar()导致系统头部隐藏而出现黑条
<img width="426" alt="image" src="https://github.com/user-attachments/assets/64478bbc-6455-4048-9ccc-b4ca317d4508" />
